### PR TITLE
Add apt-cacher-ng states to apt-cacher-formula

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,8 @@ apt-cacher
 
 Formulas to install the apt-cacher package or to configure clients to
 use a apt-cacher proxy.
+It also supports apt-cacher-ng, the successor of apt-cacher:
+https://www.unix-ag.uni-kl.de/~bloch/acng
 
 .. note::
 
@@ -12,6 +14,7 @@ use a apt-cacher proxy.
 
 Requirements
 ------------
+apt-cacher requires apache formula (apt-cacher-ng does not, as it runs in standalone mode)
 `apache-formula <https://github.com/saltstack-formulas/apache-formula>`_
 
 Available states
@@ -29,3 +32,13 @@ Available states
 ---------------------
 
   Sets up the system to use the apt-cacher server as the caching proxy
+
+``apt-cacher.ng.server``
+-------
+
+  Install and configure apt-cacher-ng
+
+``apt-cacher.ng.client``
+------------
+
+  Sets up the system to use the apt-cacher-ng server as the caching proxy

--- a/apt-cacher/ng/client.sls
+++ b/apt-cacher/ng/client.sls
@@ -1,0 +1,14 @@
+{% if grains['os_family'] == 'Debian' %}
+{% from "apt-cacher/ng/map.jinja" import apt_cacher_ng with context %}
+{%- if apt_cacher_ng.server_address %}
+
+{{ apt_cacher_ng.client_config }}:
+  file:
+    - managed
+    - user: root
+    - group: root
+    - mode: '644'
+    - source: salt://apt-cacher/ng/files/client.conf
+    - template: jinja
+{%- endif %}
+{% endif %}

--- a/apt-cacher/ng/files/client.conf
+++ b/apt-cacher/ng/files/client.conf
@@ -1,0 +1,2 @@
+{% from "apt-cacher/ng/map.jinja" import apt_cacher_ng with context %}
+Acquire::http::Proxy "http://{{ apt_cacher_ng.server_address }}:{{ apt_cacher_ng.server_port }}";

--- a/apt-cacher/ng/files/security.conf
+++ b/apt-cacher/ng/files/security.conf
@@ -1,0 +1,12 @@
+
+# This file contains confidential data and should be protected with file
+# permissions from being read by untrusted users.
+#
+# NOTE: permissions are fixated with dpkg-statoverride on Debian systems.
+# Read its manual page for details.
+
+# Basic authentication with username and password, required to
+# visit pages with administrative functionality. Format: username:password
+{% from "apt-cacher/ng/map.jinja" import apt_cacher_ng with context %}
+AdminAuth: {{ apt_cacher_ng.admin_account }}:{{ apt_cacher_ng.admin_passwd }}
+

--- a/apt-cacher/ng/files/server.conf
+++ b/apt-cacher/ng/files/server.conf
@@ -1,0 +1,5 @@
+{% from "apt-cacher/ng/map.jinja" import apt_cacher_ng with context %}
+BindAddress: {{ apt_cacher_ng.server_bind_address }}
+CacheDir: {{ apt_cacher_ng.server_cache_dir }}
+LogDir: {{ apt_cacher_ng.server_log_dir }}
+Port: {{ apt_cacher_ng.server_port }}

--- a/apt-cacher/ng/map.jinja
+++ b/apt-cacher/ng/map.jinja
@@ -1,0 +1,18 @@
+{% set apt_cacher_ng = salt['grains.filter_by']({
+    'Debian': {
+        'server_address': 'localhost',
+        'server_bind_address': '0.0.0.0',
+        'server_port': '3142',
+        'server_config': '/etc/apt-cacher-ng/zzz_acng.conf',
+        'server_cache_dir': '/var/cache/apt-cacher-ng',
+        'server_log_dir': '/var/log/apt-cacher-ng',
+        'user': 'apt-cacher-ng',
+        'group': 'apt-cacher-ng',
+        'pkg': 'apt-cacher-ng',
+        'service': 'apt-cacher-ng',
+        'credentials': '/etc/apt-cacher-ng/security.conf',
+        'client_config': '/etc/apt/apt.conf.d/80proxy',
+        'admin_account': 'root',
+        'admin_passwd': 'admin'
+    },
+}, merge=salt['pillar.get']('apt_cacher_ng')) %}

--- a/apt-cacher/ng/server.sls
+++ b/apt-cacher/ng/server.sls
@@ -1,0 +1,50 @@
+{% if grains['os_family'] == 'Debian' %}
+{% from "apt-cacher/ng/map.jinja" import apt_cacher_ng with context %}
+
+apt-cacher-ng:
+  pkg:
+    - installed
+    - name: {{ apt_cacher_ng.pkg }}
+  service:
+    - running
+    - name: {{ apt_cacher_ng.service }}
+    - enable: True
+    - watch:
+      - pkg: {{ apt_cacher_ng.pkg }}
+      - file: {{ apt_cacher_ng.credentials }}
+      - file: {{ apt_cacher_ng.server_config }}
+      - file: {{ apt_cacher_ng.server_cache_dir }}
+      - file: {{ apt_cacher_ng.server_log_dir }}
+
+{{ apt_cacher_ng.server_config }}:
+  file:
+    - managed
+    - user: root
+    - group: root
+    - mode: '644'
+    - source: salt://apt-cacher/ng/files/server.conf
+    - template: jinja
+
+{{ apt_cacher_ng.server_cache_dir }}:
+  file:
+    - directory
+    - user: {{ apt_cacher_ng.user }}
+    - group: {{ apt_cacher_ng.group }}
+    - mode: '2755'
+
+{{ apt_cacher_ng.server_log_dir }}:
+  file:
+    - directory
+    - user: {{ apt_cacher_ng.user }}
+    - group: {{ apt_cacher_ng.group }}
+    - mode: '2755'
+
+{{ apt_cacher_ng.credentials }}:
+  file:
+    - managed
+    - user: {{ apt_cacher_ng.user }}
+    - group: {{ apt_cacher_ng.group }}
+    - mode: '600'
+    - source: salt://apt-cacher/ng/files/security.conf
+    - template: jinja
+{% endif %}

--- a/pillar.client.example
+++ b/pillar.client.example
@@ -1,2 +1,0 @@
-apt_cacher:
-  host: cacher.mycompany.com

--- a/pillar.example
+++ b/pillar.example
@@ -1,0 +1,23 @@
+apt_cacher:
+  host: cacher.mycompany.com
+  admin_email: admin@mycompany.com
+
+apt_cacher_ng:
+  # Setting up server_address is the minimal configuration requirement.
+  # Others options has default sane values (see map.jinja).
+  # server_address is the address access by apt-cacher-ng clients.
+  # It could be an IPv4 or a FQDN; This address MUST be resolvable by clients.
+  server_address: pkgproxy.example.com
+
+  # Server binds to this address.
+  # It could be the same value as server_address (in most cases).
+  server_bind_address: 192.168.33.10
+
+  server_port: 3142
+  cache_dir: /var/cache/apt-cacher-ng
+  log_dir: /var/log/apt-cacher-ng
+
+  # Credentials for apt-cacher-ng Web management interface.
+  # http://<server_adress>:<server_port>/acng-report.html
+  admin_account: root
+  admin_passwd: admin

--- a/pillar.server.example
+++ b/pillar.server.example
@@ -1,2 +1,0 @@
-apt_cacher:
-  admin_email: admin@mycompany.com


### PR DESCRIPTION
Hello,

As suggested in this topic (https://groups.google.com/forum/?hl=fr#!topic/salt-users/JnGxhQm_5fI), i would like to submit those two states:
- apt-cacher.ng.server
- apt-cacher.ng.client

Best regards,
