### PR TITLE
Use makedirs for server_cache_dir and server_log_dir

### DIFF
--- a/apt-cacher/ng/server.sls
+++ b/apt-cacher/ng/server.sls
@@ -28,6 +28,7 @@ apt-cacher-ng:
 {{ apt_cacher_ng.server_cache_dir }}:
   file:
     - directory
+    - makedirs: True
     - user: {{ apt_cacher_ng.user }}
     - group: {{ apt_cacher_ng.group }}
     - mode: '2755'
@@ -35,6 +36,7 @@ apt-cacher-ng:
 {{ apt_cacher_ng.server_log_dir }}:
   file:
     - directory
+    - makedirs: True
     - user: {{ apt_cacher_ng.user }}
     - group: {{ apt_cacher_ng.group }}
     - mode: '2755'

--- a/pillar.example
+++ b/pillar.example
@@ -14,8 +14,8 @@ apt_cacher_ng:
   server_bind_address: 192.168.33.10
 
   server_port: 3142
-  cache_dir: /var/cache/apt-cacher-ng
-  log_dir: /var/log/apt-cacher-ng
+  server_cache_dir: /var/cache/apt-cacher-ng
+  server_log_dir: /var/log/apt-cacher-ng
 
   # Credentials for apt-cacher-ng Web management interface.
   # http://<server_adress>:<server_port>/acng-report.html


### PR DESCRIPTION
Hi,

Using this option prevents the apt-cacher.ng.server state to fail if parent directory does not exists.
