### PR TITLE
Fix typo in template 01proxy

### DIFF
--- a/apt-cacher/files/01proxy
+++ b/apt-cacher/files/01proxy
@@ -1,2 +1,2 @@
-{% set apt_cacher = pillar.get('apt-cacher', {}) -%}
+{% set apt_cacher = pillar.get('apt_cacher', {}) -%}
 Acquire::http::Proxy "http://{{ apt_cacher.get('host', 'localhost') }}:3142";


### PR DESCRIPTION
The key is always null and thus localhost is always used no matter
way. This correction lets users specify the apt-cacher host.
