### PR TITLE
Proper path for server_config

### DIFF
--- a/apt-cacher/ng/map.jinja
+++ b/apt-cacher/ng/map.jinja
@@ -3,7 +3,7 @@
         'server_address': 'localhost',
         'server_bind_address': '0.0.0.0',
         'server_port': '3142',
-        'server_config': '/etc/apt-cacher-ng/zzz_acng.conf',
+        'server_config': '/etc/apt-cacher-ng/acng.conf',
         'server_cache_dir': '/var/cache/apt-cacher-ng',
         'server_log_dir': '/var/log/apt-cacher-ng',
         'user': 'apt-cacher-ng',


### PR DESCRIPTION
Fix for addressing #8. This is the default configuration path for `apt-cacher-ng`.
