### PR TITLE
Support include and require_in pillar options.

### DIFF
--- a/apt-cacher/ng/server.sls
+++ b/apt-cacher/ng/server.sls
@@ -1,6 +1,13 @@
 {% if grains['os_family'] == 'Debian' %}
 {% from "apt-cacher/ng/map.jinja" import apt_cacher_ng with context %}
 
+{% if 'include' in apt_cacher_ng %}
+include:
+{% for include_line in apt_cacher_ng.include %}
+  - {{ include_line }}
+{% endfor %}
+{% endif %}
+
 apt-cacher-ng:
   pkg.installed:
     - name: {{ apt_cacher_ng.pkg }}
@@ -13,6 +20,12 @@ apt-cacher-ng:
       - file: {{ apt_cacher_ng.server_config }}
       - file: {{ apt_cacher_ng.server_cache_dir }}
       - file: {{ apt_cacher_ng.server_log_dir }}
+{% if 'require_in' in apt_cacher_ng %}
+    - require_in:
+{% for require_in in apt_cacher_ng.require_in %}
+      - {{ require_in }}
+{% endfor %}
+{% endif %}
 
 {{ apt_cacher_ng.server_config }}:
   file.managed:


### PR DESCRIPTION
Can be used to have an external repositories state depend on apt-cacher-ng being deployed first. Otherwise, things will break if highstate is run on apt-cacher-ng and it cannot successfully run `apt-get update` in the repositories state because the repository source doesn't exist.