### PR TITLE
Support require pillar option

### DIFF
--- a/apt-cacher/ng/server.sls
+++ b/apt-cacher/ng/server.sls
@@ -1,12 +1,12 @@
 {% if grains['os_family'] == 'Debian' %}
 {% from "apt-cacher/ng/map.jinja" import apt_cacher_ng with context %}
 
-{% if 'include' in apt_cacher_ng %}
+{%- if 'include' in apt_cacher_ng %}
 include:
-{% for include_line in apt_cacher_ng.include %}
+{%- for include_line in apt_cacher_ng.include %}
   - {{ include_line }}
-{% endfor %}
-{% endif %}
+{%- endfor %}
+{%- endif %}
 
 apt-cacher-ng:
   pkg.installed:

--- a/apt-cacher/ng/server.sls
+++ b/apt-cacher/ng/server.sls
@@ -20,12 +20,18 @@ apt-cacher-ng:
       - file: {{ apt_cacher_ng.server_config }}
       - file: {{ apt_cacher_ng.server_cache_dir }}
       - file: {{ apt_cacher_ng.server_log_dir }}
-{% if 'require_in' in apt_cacher_ng %}
+{%- if 'require' in apt_cacher_ng %}
+    - require:
+{%- for require in apt_cacher_ng.require %}
+      - {{ require }}
+{%- endfor %}
+{%- endif %}
+{%- if 'require_in' in apt_cacher_ng %}
     - require_in:
-{% for require_in in apt_cacher_ng.require_in %}
+{%- for require_in in apt_cacher_ng.require_in %}
       - {{ require_in }}
-{% endfor %}
-{% endif %}
+{%- endfor %}
+{%- endif %}
 
 {{ apt_cacher_ng.server_config }}:
   file.managed:


### PR DESCRIPTION
I found it necessary to modify files under `/etc/apt-cacher-ng/` for our setup, but don't want to fork the formula for something specific to my setup. By adding support for the `require` directive, I can put all my environment-specific apt-cacher-ng changes in a new state and require it by the service. This is a similar situation to my previous PR to use the `require_in` pillar data.

Here is an example of what is now possible (taken from my pillar):

```
apt_cacher_ng:
  ...
  include:
    - repositories.sources
    - apt-cacher-ng-fixes.server
  require:
    - 'file: /etc/apt-cacher-ng/backends_debian'
  require_in:
    - 'pkgrepo: deb jessie-backports'
    - 'pkgrepo: deb-src jessie-backports'
```

I have my state sls containing `file: /etc/apt-cacher-ng/backends_debian` configured to depend on the apt-cacher-ng package, so first the apt-cacher-ng package gets installed, then the `backends_debian` file is updated, then the apt-cacher-ng server starts, and finally the repository sources.list files are modified via my included repositories.sources state. All without site-specific changes to the apt-cacher formula (assuming this PR is accepted).