### PR TITLE
Drop default AdminAuth

### DIFF
--- a/apt-cacher/ng/files/security.conf
+++ b/apt-cacher/ng/files/security.conf
@@ -7,6 +7,10 @@
 
 # Basic authentication with username and password, required to
 # visit pages with administrative functionality. Format: username:password
-{% from "apt-cacher/ng/map.jinja" import apt_cacher_ng with context %}
-AdminAuth: {{ apt_cacher_ng.admin_account }}:{{ apt_cacher_ng.admin_passwd }}
+{%- set cfg = salt['pillar.get']('apt_cacher_ng', {}) %}
+{%- set admin_account = cfg.get('admin_account', False) %}
+{%- set admin_passwd = cfg.get('admin_passwd', False) %}
+{%- if admin_account and admin_passwd %}
+AdminAuth: {{ admin_account }}:{{ admin_passwd }}
+{%- endif %}
 

--- a/apt-cacher/ng/map.jinja
+++ b/apt-cacher/ng/map.jinja
@@ -13,7 +13,5 @@
         'service': 'apt-cacher-ng',
         'credentials': '/etc/apt-cacher-ng/security.conf',
         'client_config': '/etc/apt/apt.conf.d/80proxy',
-        'admin_account': 'root',
-        'admin_passwd': 'admin'
     },
 }, merge=salt['pillar.get']('apt_cacher_ng')) %}


### PR DESCRIPTION
IMHO `AdminAuth` must not have default credentials. If the admin interface is needed, there must unique, secret credentials.

This patch drops the default credentials from `map.jinia` and checks for presence of `admin_account` and `admin_passwd` _before_ setting `AdminAuth`.