### PR TITLE
ng.client: don't cache https://

### DIFF
--- a/apt-cacher/ng/files/client.conf
+++ b/apt-cacher/ng/files/client.conf
@@ -1,2 +1,3 @@
 {% from "apt-cacher/ng/map.jinja" import apt_cacher_ng with context %}
 Acquire::http::Proxy "http://{{ apt_cacher_ng.server_address }}:{{ apt_cacher_ng.server_port }}";
+Acquire::https::Proxy "DIRECT";


### PR DESCRIPTION
Prevents the Apt client from trying to cache https:// URIs. Otherwise this error occurs:
`Received HTTP code 403 from proxy after CONNECT`.

AFAIK this patch is necessary to use [apt-transport-https](https://packages.debian.org/wheezy/apt-transport-https).