### PR TITLE
no proxy for local mirrors

### DIFF
--- a/apt-cacher/ng/files/client.conf
+++ b/apt-cacher/ng/files/client.conf
@@ -1,3 +1,6 @@
 {% from "apt-cacher/ng/map.jinja" import apt_cacher_ng with context -%}
 Acquire::http::Proxy "http://{{ apt_cacher_ng.server_address }}:{{ apt_cacher_ng.server_port }}";
 Acquire::https::Proxy "{{ apt_cacher_ng.https_proxy }}";
+{% for host in apt_cacher_ng.local_mirrors -%}
+Acquire::http::Proxy::{{ host }} "DIRECT";
+{% endfor -%}

--- a/apt-cacher/ng/map.jinja
+++ b/apt-cacher/ng/map.jinja
@@ -14,5 +14,6 @@
         'credentials': '/etc/apt-cacher-ng/security.conf',
         'client_config': '/etc/apt/apt.conf.d/80proxy',
         'https_proxy': 'DIRECT',
+        'local_mirrors': [],
     },
 }, merge=salt['pillar.get']('apt_cacher_ng')) %}

--- a/pillar.example
+++ b/pillar.example
@@ -36,6 +36,12 @@ apt_cacher_ng:
   # Default value ignores proxy for HTTPS connections
   https_proxy: DIRECT
 
+  # Local mirrors don't need a proxy
+  # See https://linux.die.net/man/5/apt.conf
+  local_mirrors:
+    - 192.168.0.1
+    - host.example.test
+
 
 ##
 # require/require_in/include example


### PR DESCRIPTION
Accessing local mirrors via proxy just adds latency and wastes disk space. (And in my case `apt-cacher-ng` didn't play nice with the local mirrors.)